### PR TITLE
Update build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,9 +21,9 @@ android {
 
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])	
-    testCompile 'junit:junit:4.12'	
-    compile 'com.android.support:appcompat-v7:23.3.0'	
-    compile 'com.android.support:support-v4:23.3.0'
-    compile 'com.android.support:design:23.3.0'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])	
+    testImplementation 'junit:junit:4.12'	
+    implementation 'com.android.support:appcompat-v7:23.4.0'	
+    implementation 'com.android.support:support-v4:23.4.0'
+    implementation 'com.android.support:design:23.4.0'
 }


### PR DESCRIPTION
Update version 23.3.0 -> 23.4.0.

Replaced:
compile -> implementation
testCompile -> testImplementation

Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html