### PR TITLE
1.29 Manage audio focus properly - updated deprecated elements and gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '27.0.3'
+    compileSdkVersion 29
+    buildToolsVersion '29.0.3'
 
     defaultConfig {
         applicationId "com.example.android.miwok"
-        minSdkVersion 15
-        targetSdkVersion 23
+        minSdkVersion 27
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
     }
@@ -21,9 +21,14 @@ android {
 
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])	
-    testCompile 'junit:junit:4.12'	
-    compile 'com.android.support:appcompat-v7:23.3.0'	
-    compile 'com.android.support:support-v4:23.3.0'
-    compile 'com.android.support:design:23.3.0'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    testImplementation 'junit:junit:4.13'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    implementation 'com.google.android.material:material:1.2.0-alpha06'
+    implementation 'androidx.fragment:fragment:1.2.4'
+    debugImplementation 'androidx.fragment:fragment-testing:1.2.4'
+    implementation 'com.android.support:design:29.0.0'
+    implementation "androidx.media:media:1.1.0"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,11 +24,11 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     testImplementation 'junit:junit:4.13'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'com.google.android.material:material:1.2.0-alpha06'
-    implementation 'androidx.fragment:fragment:1.2.4'
-    debugImplementation 'androidx.fragment:fragment-testing:1.2.4'
+    implementation 'com.google.android.material:material:1.3.0-alpha03'
+    implementation 'androidx.fragment:fragment:1.2.5'
+    debugImplementation 'androidx.fragment:fragment-testing:1.2.5'
     implementation 'com.android.support:design:29.0.0'
-    implementation "androidx.media:media:1.1.0"
+    implementation "androidx.media:media:1.2.0"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "com.example.android.miwok"
-        minSdkVersion 27
+        minSdkVersion 25
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"

--- a/app/src/main/java/com/example/android/miwok/ColorsActivity.java
+++ b/app/src/main/java/com/example/android/miwok/ColorsActivity.java
@@ -40,32 +40,19 @@ public class ColorsActivity extends AppCompatActivity {
     private AudioManager mAudioManager;
 
     private AudioFocusRequestCompat mAudioFocusRequest;
-
-    /**
-     * This listener gets triggered when the {@link MediaPlayer} has completed
-     * playing the audio file.
-     */
-    /*private MediaPlayer.OnCompletionListener mCompletionListener = new MediaPlayer.OnCompletionListener() {
-        @Override
-        public void onCompletion(MediaPlayer mediaPlayer) {
-            // Now that the sound file has finished playing, release the media player resources.
-            releaseMediaPlayer();
-        }
-    };*/
-
     private MediaPlayer.OnCompletionListener mOnCompletionListener;
 
-    /**
-     * This listener gets triggered whenever the audio focus changes
-     * (i.e., we gain or lose audio focus because of another app or device).
-     */
-
+    private ArrayList<Word> words;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.word_list);
 
+        /*
+          This listener gets triggered when the {@link MediaPlayer} has completed
+          playing the audio file.
+         */
         mOnCompletionListener = new MediaPlayer.OnCompletionListener() {
             @Override
             public void onCompletion(MediaPlayer mp) {
@@ -73,6 +60,10 @@ public class ColorsActivity extends AppCompatActivity {
             }
         };
 
+        /*
+         * This listener gets triggered whenever the audio focus changes
+         * (i.e., we gain or lose audio focus because of another app or device).
+         */
          AudioManager.OnAudioFocusChangeListener audioFocusChangeListener = new AudioManager.OnAudioFocusChangeListener() {
             @Override
             public void onAudioFocusChange(int focusChange) {
@@ -113,7 +104,7 @@ public class ColorsActivity extends AppCompatActivity {
         mAudioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
 
         // Create a list of words
-        final ArrayList<Word> words = new ArrayList<Word>();
+        words = new ArrayList<Word>();
         words.add(new Word(R.string.color_red, R.string.miwok_color_red,
                 R.drawable.color_red, R.raw.color_red));
         words.add(new Word(R.string.color_mustard_yellow, R.string.miwok_color_mustard_yellow,

--- a/app/src/main/java/com/example/android/miwok/ColorsActivity.java
+++ b/app/src/main/java/com/example/android/miwok/ColorsActivity.java
@@ -18,13 +18,18 @@ package com.example.android.miwok;
 import android.content.Context;
 import android.media.AudioManager;
 import android.media.MediaPlayer;
-import android.support.v7.app.AppCompatActivity;
+
 import android.os.Bundle;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ListView;
 
 import java.util.ArrayList;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.media.AudioAttributesCompat;
+import androidx.media.AudioFocusRequestCompat;
+import androidx.media.AudioManagerCompat;
 
 public class ColorsActivity extends AppCompatActivity {
 
@@ -34,51 +39,75 @@ public class ColorsActivity extends AppCompatActivity {
     /** Handles audio focus when playing a sound file */
     private AudioManager mAudioManager;
 
+    private AudioFocusRequestCompat mAudioFocusRequest;
+
     /**
      * This listener gets triggered when the {@link MediaPlayer} has completed
      * playing the audio file.
      */
-    private MediaPlayer.OnCompletionListener mCompletionListener = new MediaPlayer.OnCompletionListener() {
+    /*private MediaPlayer.OnCompletionListener mCompletionListener = new MediaPlayer.OnCompletionListener() {
         @Override
         public void onCompletion(MediaPlayer mediaPlayer) {
             // Now that the sound file has finished playing, release the media player resources.
             releaseMediaPlayer();
         }
-    };
+    };*/
+
+    private MediaPlayer.OnCompletionListener mOnCompletionListener;
 
     /**
      * This listener gets triggered whenever the audio focus changes
      * (i.e., we gain or lose audio focus because of another app or device).
      */
-    private AudioManager.OnAudioFocusChangeListener mOnAudioFocusChangeListener = new AudioManager.OnAudioFocusChangeListener() {
-        @Override
-        public void onAudioFocusChange(int focusChange) {
-            if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT ||
-                    focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK) {
-                // The AUDIOFOCUS_LOSS_TRANSIENT case means that we've lost audio focus for a
-                // short amount of time. The AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK case means that
-                // our app is allowed to continue playing sound but at a lower volume. We'll treat
-                // both cases the same way because our app is playing short sound files.
 
-                // Pause playback and reset player to the start of the file. That way, we can
-                // play the word from the beginning when we resume playback.
-                mMediaPlayer.pause();
-                mMediaPlayer.seekTo(0);
-            } else if (focusChange == AudioManager.AUDIOFOCUS_GAIN) {
-                // The AUDIOFOCUS_GAIN case means we have regained focus and can resume playback.
-                mMediaPlayer.start();
-            } else if (focusChange == AudioManager.AUDIOFOCUS_LOSS) {
-                // The AUDIOFOCUS_LOSS case means we've lost audio focus and
-                // Stop playback and clean up resources
-                releaseMediaPlayer();
-            }
-        }
-    };
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.word_list);
+
+        mOnCompletionListener = new MediaPlayer.OnCompletionListener() {
+            @Override
+            public void onCompletion(MediaPlayer mp) {
+                releaseMediaPlayer();
+            }
+        };
+
+         AudioManager.OnAudioFocusChangeListener audioFocusChangeListener = new AudioManager.OnAudioFocusChangeListener() {
+            @Override
+            public void onAudioFocusChange(int focusChange) {
+                if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT ||
+                        focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK) {
+                    // The AUDIOFOCUS_LOSS_TRANSIENT case means that we've lost audio focus for a
+                    // short amount of time. The AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK case means that
+                    // our app is allowed to continue playing sound but at a lower volume. We'll treat
+                    // both cases the same way because our app is playing short sound files.
+
+                    // Pause playback and reset player to the start of the file. That way, we can
+                    // play the word from the beginning when we resume playback.
+                    mMediaPlayer.pause();
+                    mMediaPlayer.seekTo(0);
+                } else if (focusChange == AudioManager.AUDIOFOCUS_GAIN) {
+                    // The AUDIOFOCUS_GAIN case means we have regained focus and can resume playback.
+                    mMediaPlayer.start();
+                } else if (focusChange == AudioManager.AUDIOFOCUS_LOSS) {
+                    // The AUDIOFOCUS_LOSS case means we've lost audio focus and
+                    // Stop playback and clean up resources
+                    releaseMediaPlayer();
+                }
+            }
+        };
+
+        AudioAttributesCompat audioAttributes = new AudioAttributesCompat.Builder()
+                .setContentType(AudioAttributesCompat.CONTENT_TYPE_SPEECH)
+                .setUsage(AudioAttributesCompat.USAGE_MEDIA)
+                .build();
+
+        mAudioFocusRequest = new AudioFocusRequestCompat
+                .Builder(AudioManagerCompat.AUDIOFOCUS_GAIN_TRANSIENT)
+                .setAudioAttributes(audioAttributes)
+                .setOnAudioFocusChangeListener(audioFocusChangeListener)
+                .build();
 
         // Create and setup the {@link AudioManager} to request audio focus
         mAudioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
@@ -129,22 +158,16 @@ public class ColorsActivity extends AppCompatActivity {
                 // Request audio focus so in order to play the audio file. The app needs to play a
                 // short audio file, so we will request audio focus with a short amount of time
                 // with AUDIOFOCUS_GAIN_TRANSIENT.
-                int result = mAudioManager.requestAudioFocus(mOnAudioFocusChangeListener,
-                        AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN_TRANSIENT);
+                int result = AudioManagerCompat.requestAudioFocus(
+                        mAudioManager,
+                        mAudioFocusRequest);
 
                 if (result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
-                    // We have audio focus now.
 
-                    // Create and setup the {@link MediaPlayer} for the audio resource associated
-                    // with the current word
-                    mMediaPlayer = MediaPlayer.create(ColorsActivity.this, word.getAudioResourceId());
-
-                    // Start the audio file
+                    mMediaPlayer = MediaPlayer.create(ColorsActivity.this, words.get(position).getAudioResourceId());
                     mMediaPlayer.start();
+                    mMediaPlayer.setOnCompletionListener(mOnCompletionListener);
 
-                    // Setup a listener on the media player, so that we can stop and release the
-                    // media player once the sound has finished playing.
-                    mMediaPlayer.setOnCompletionListener(mCompletionListener);
                 }
             }
         });
@@ -175,7 +198,9 @@ public class ColorsActivity extends AppCompatActivity {
 
             // Regardless of whether or not we were granted audio focus, abandon it. This also
             // unregisters the AudioFocusChangeListener so we don't get anymore callbacks.
-            mAudioManager.abandonAudioFocus(mOnAudioFocusChangeListener);
+            AudioManagerCompat.abandonAudioFocusRequest(
+                    mAudioManager,
+                    mAudioFocusRequest);
         }
     }
 }

--- a/app/src/main/java/com/example/android/miwok/FamilyActivity.java
+++ b/app/src/main/java/com/example/android/miwok/FamilyActivity.java
@@ -18,13 +18,15 @@ package com.example.android.miwok;
 import android.content.Context;
 import android.media.AudioManager;
 import android.media.MediaPlayer;
-import android.support.v7.app.AppCompatActivity;
+
 import android.os.Bundle;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ListView;
 
 import java.util.ArrayList;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 public class FamilyActivity extends AppCompatActivity {
 

--- a/app/src/main/java/com/example/android/miwok/FamilyActivity.java
+++ b/app/src/main/java/com/example/android/miwok/FamilyActivity.java
@@ -27,6 +27,9 @@ import android.widget.ListView;
 import java.util.ArrayList;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.media.AudioAttributesCompat;
+import androidx.media.AudioFocusRequestCompat;
+import androidx.media.AudioManagerCompat;
 
 public class FamilyActivity extends AppCompatActivity {
 
@@ -36,54 +39,70 @@ public class FamilyActivity extends AppCompatActivity {
     /** Handles audio focus when playing a sound file */
     private AudioManager mAudioManager;
 
-    /**
-     * This listener gets triggered when the {@link MediaPlayer} has completed
-     * playing the audio file.
-     */
-    private MediaPlayer.OnCompletionListener mCompletionListener = new MediaPlayer.OnCompletionListener() {
-        @Override
-        public void onCompletion(MediaPlayer mediaPlayer) {
-            // Now that the sound file has finished playing, release the media player resources.
-            releaseMediaPlayer();
-        }
-    };
+    private AudioFocusRequestCompat mAudioFocusRequest;
+    private MediaPlayer.OnCompletionListener mOnCompletionListener;
 
-    /**
-     * This listener gets triggered whenever the audio focus changes
-     * (i.e., we gain or lose audio focus because of another app or device).
-     */
-    private AudioManager.OnAudioFocusChangeListener mOnAudioFocusChangeListener = new AudioManager.OnAudioFocusChangeListener() {
-        @Override
-        public void onAudioFocusChange(int focusChange) {
-            if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT ||
-                    focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK) {
-                // The AUDIOFOCUS_LOSS_TRANSIENT case means that we've lost audio focus for a
-                // short amount of time. The AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK case means that
-                // our app is allowed to continue playing sound but at a lower volume. We'll treat
-                // both cases the same way because our app is playing short sound files.
-
-                // Pause playback and reset player to the start of the file. That way, we can
-                // play the word from the beginning when we resume playback.
-                mMediaPlayer.pause();
-                mMediaPlayer.seekTo(0);
-            } else if (focusChange == AudioManager.AUDIOFOCUS_GAIN) {
-                // The AUDIOFOCUS_GAIN case means we have regained focus and can resume playback.
-                mMediaPlayer.start();
-            } else if (focusChange == AudioManager.AUDIOFOCUS_LOSS) {
-                // The AUDIOFOCUS_LOSS case means we've lost audio focus and
-                // Stop playback and clean up resources
-                releaseMediaPlayer();
-            }
-        }
-    };
+    private ArrayList<Word> words;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.word_list);
 
+        /*
+         * This listener gets triggered when the {@link MediaPlayer} has completed
+         * playing the audio file.
+         */
+        mOnCompletionListener = new MediaPlayer.OnCompletionListener() {
+            @Override
+            public void onCompletion(MediaPlayer mediaPlayer) {
+                // Now that the sound file has finished playing, release the media player resources.
+                releaseMediaPlayer();
+            }
+        };
+
+        /*
+         * This listener gets triggered whenever the audio focus changes
+         * (i.e., we gain or lose audio focus because of another app or device).
+         */
+         AudioManager.OnAudioFocusChangeListener audioFocusChangeListener = new AudioManager.OnAudioFocusChangeListener() {
+            @Override
+            public void onAudioFocusChange(int focusChange) {
+                if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT ||
+                        focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK) {
+                    // The AUDIOFOCUS_LOSS_TRANSIENT case means that we've lost audio focus for a
+                    // short amount of time. The AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK case means that
+                    // our app is allowed to continue playing sound but at a lower volume. We'll treat
+                    // both cases the same way because our app is playing short sound files.
+
+                    // Pause playback and reset player to the start of the file. That way, we can
+                    // play the word from the beginning when we resume playback.
+                    mMediaPlayer.pause();
+                    mMediaPlayer.seekTo(0);
+                } else if (focusChange == AudioManager.AUDIOFOCUS_GAIN) {
+                    // The AUDIOFOCUS_GAIN case means we have regained focus and can resume playback.
+                    mMediaPlayer.start();
+                } else if (focusChange == AudioManager.AUDIOFOCUS_LOSS) {
+                    // The AUDIOFOCUS_LOSS case means we've lost audio focus and
+                    // Stop playback and clean up resources
+                    releaseMediaPlayer();
+                }
+            }
+        };
+
         // Create and setup the {@link AudioManager} to request audio focus
         mAudioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+
+        AudioAttributesCompat audioAttributes = new AudioAttributesCompat.Builder()
+                .setContentType(AudioAttributesCompat.CONTENT_TYPE_SPEECH)
+                .setUsage(AudioAttributesCompat.USAGE_MEDIA)
+                .build();
+
+        mAudioFocusRequest = new AudioFocusRequestCompat
+                .Builder(AudioManagerCompat.AUDIOFOCUS_GAIN_TRANSIENT)
+                .setAudioAttributes(audioAttributes)
+                .setOnAudioFocusChangeListener(audioFocusChangeListener)
+                .build();
 
         // Create a list of words
         final ArrayList<Word> words = new ArrayList<Word>();
@@ -135,8 +154,7 @@ public class FamilyActivity extends AppCompatActivity {
                 // Request audio focus so in order to play the audio file. The app needs to play a
                 // short audio file, so we will request audio focus with a short amount of time
                 // with AUDIOFOCUS_GAIN_TRANSIENT.
-                int result = mAudioManager.requestAudioFocus(mOnAudioFocusChangeListener,
-                        AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN_TRANSIENT);
+                int result =AudioManagerCompat.requestAudioFocus(mAudioManager, mAudioFocusRequest);
 
                 if (result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
                     // We have audio focus now.
@@ -150,7 +168,7 @@ public class FamilyActivity extends AppCompatActivity {
 
                     // Setup a listener on the media player, so that we can stop and release the
                     // media player once the sound has finished playing.
-                    mMediaPlayer.setOnCompletionListener(mCompletionListener);
+                    mMediaPlayer.setOnCompletionListener(mOnCompletionListener);
                 }
             }
         });
@@ -181,7 +199,7 @@ public class FamilyActivity extends AppCompatActivity {
 
             // Regardless of whether or not we were granted audio focus, abandon it. This also
             // unregisters the AudioFocusChangeListener so we don't get anymore callbacks.
-            mAudioManager.abandonAudioFocus(mOnAudioFocusChangeListener);
+            AudioManagerCompat.abandonAudioFocusRequest(mAudioManager,mAudioFocusRequest);
         }
     }
 }

--- a/app/src/main/java/com/example/android/miwok/MainActivity.java
+++ b/app/src/main/java/com/example/android/miwok/MainActivity.java
@@ -17,10 +17,12 @@ package com.example.android.miwok;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
+
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 public class MainActivity extends AppCompatActivity {
 

--- a/app/src/main/java/com/example/android/miwok/NumbersActivity.java
+++ b/app/src/main/java/com/example/android/miwok/NumbersActivity.java
@@ -27,6 +27,9 @@ import android.widget.ListView;
 import java.util.ArrayList;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.media.AudioAttributesCompat;
+import androidx.media.AudioFocusRequestCompat;
+import androidx.media.AudioManagerCompat;
 
 public class NumbersActivity extends AppCompatActivity {
 
@@ -36,54 +39,71 @@ public class NumbersActivity extends AppCompatActivity {
     /** Handles audio focus when playing a sound file */
     private AudioManager mAudioManager;
 
-    /**
-     * This listener gets triggered whenever the audio focus changes
-     * (i.e., we gain or lose audio focus because of another app or device).
-     */
-    private AudioManager.OnAudioFocusChangeListener mOnAudioFocusChangeListener = new AudioManager.OnAudioFocusChangeListener() {
-        @Override
-        public void onAudioFocusChange(int focusChange) {
-            if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT ||
-                    focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK) {
-                // The AUDIOFOCUS_LOSS_TRANSIENT case means that we've lost audio focus for a
-                // short amount of time. The AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK case means that
-                // our app is allowed to continue playing sound but at a lower volume. We'll treat
-                // both cases the same way because our app is playing short sound files.
+    private AudioFocusRequestCompat mAudioFocusRequest;
+    private MediaPlayer.OnCompletionListener mOnCompletionListener;
 
-                // Pause playback and reset player to the start of the file. That way, we can
-                // play the word from the beginning when we resume playback.
-                mMediaPlayer.pause();
-                mMediaPlayer.seekTo(0);
-            } else if (focusChange == AudioManager.AUDIOFOCUS_GAIN) {
-                // The AUDIOFOCUS_GAIN case means we have regained focus and can resume playback.
-                mMediaPlayer.start();
-            } else if (focusChange == AudioManager.AUDIOFOCUS_LOSS) {
-                // The AUDIOFOCUS_LOSS case means we've lost audio focus and
-                // Stop playback and clean up resources
-                releaseMediaPlayer();
-            }
-        }
-    };
-
-    /**
-     * This listener gets triggered when the {@link MediaPlayer} has completed
-     * playing the audio file.
-     */
-    private MediaPlayer.OnCompletionListener mCompletionListener = new MediaPlayer.OnCompletionListener() {
-        @Override
-        public void onCompletion(MediaPlayer mediaPlayer) {
-            // Now that the sound file has finished playing, release the media player resources.
-            releaseMediaPlayer();
-        }
-    };
+    private ArrayList<Word> words;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.word_list);
 
+
+        /*
+         * This listener gets triggered when the {@link MediaPlayer} has completed
+         * playing the audio file.
+         */
+        mOnCompletionListener = new MediaPlayer.OnCompletionListener() {
+            @Override
+            public void onCompletion(MediaPlayer mediaPlayer) {
+                // Now that the sound file has finished playing, release the media player resources.
+                releaseMediaPlayer();
+            }
+        };
+
+        /*
+         * This listener gets triggered whenever the audio focus changes
+         * (i.e., we gain or lose audio focus because of another app or device).
+         */
+         AudioManager.OnAudioFocusChangeListener audioFocusChangeListener = new AudioManager.OnAudioFocusChangeListener() {
+            @Override
+            public void onAudioFocusChange(int focusChange) {
+                if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT ||
+                        focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK) {
+                    // The AUDIOFOCUS_LOSS_TRANSIENT case means that we've lost audio focus for a
+                    // short amount of time. The AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK case means that
+                    // our app is allowed to continue playing sound but at a lower volume. We'll treat
+                    // both cases the same way because our app is playing short sound files.
+
+                    // Pause playback and reset player to the start of the file. That way, we can
+                    // play the word from the beginning when we resume playback.
+                    mMediaPlayer.pause();
+                    mMediaPlayer.seekTo(0);
+                } else if (focusChange == AudioManager.AUDIOFOCUS_GAIN) {
+                    // The AUDIOFOCUS_GAIN case means we have regained focus and can resume playback.
+                    mMediaPlayer.start();
+                } else if (focusChange == AudioManager.AUDIOFOCUS_LOSS) {
+                    // The AUDIOFOCUS_LOSS case means we've lost audio focus and
+                    // Stop playback and clean up resources
+                    releaseMediaPlayer();
+                }
+            }
+        };
+
         // Create and setup the {@link AudioManager} to request audio focus
         mAudioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+
+        AudioAttributesCompat audioAttributes = new AudioAttributesCompat.Builder()
+                .setContentType(AudioAttributesCompat.CONTENT_TYPE_SPEECH)
+                .setUsage(AudioAttributesCompat.USAGE_MEDIA)
+                .build();
+
+        mAudioFocusRequest = new AudioFocusRequestCompat
+                .Builder(AudioManagerCompat.AUDIOFOCUS_GAIN_TRANSIENT)
+                .setAudioAttributes(audioAttributes)
+                .setOnAudioFocusChangeListener(audioFocusChangeListener)
+                .build();
 
         // Create a list of words
         final ArrayList<Word> words = new ArrayList<Word>();
@@ -135,8 +155,7 @@ public class NumbersActivity extends AppCompatActivity {
                 // Request audio focus so in order to play the audio file. The app needs to play a
                 // short audio file, so we will request audio focus with a short amount of time
                 // with AUDIOFOCUS_GAIN_TRANSIENT.
-                int result = mAudioManager.requestAudioFocus(mOnAudioFocusChangeListener,
-                        AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN_TRANSIENT);
+                int result =AudioManagerCompat.requestAudioFocus(mAudioManager, mAudioFocusRequest);
 
                 if (result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
                     // We have audio focus now.
@@ -150,7 +169,7 @@ public class NumbersActivity extends AppCompatActivity {
 
                     // Setup a listener on the media player, so that we can stop and release the
                     // media player once the sound has finished playing.
-                    mMediaPlayer.setOnCompletionListener(mCompletionListener);
+                    mMediaPlayer.setOnCompletionListener(mOnCompletionListener);
                 }
             }
         });
@@ -181,7 +200,7 @@ public class NumbersActivity extends AppCompatActivity {
 
             // Regardless of whether or not we were granted audio focus, abandon it. This also
             // unregisters the AudioFocusChangeListener so we don't get anymore callbacks.
-            mAudioManager.abandonAudioFocus(mOnAudioFocusChangeListener);
+            AudioManagerCompat.abandonAudioFocusRequest(mAudioManager,mAudioFocusRequest);
         }
     }
 }

--- a/app/src/main/java/com/example/android/miwok/NumbersActivity.java
+++ b/app/src/main/java/com/example/android/miwok/NumbersActivity.java
@@ -19,12 +19,14 @@ import android.content.Context;
 import android.media.AudioManager;
 import android.media.MediaPlayer;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
+
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ListView;
 
 import java.util.ArrayList;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 public class NumbersActivity extends AppCompatActivity {
 

--- a/app/src/main/java/com/example/android/miwok/PhrasesActivity.java
+++ b/app/src/main/java/com/example/android/miwok/PhrasesActivity.java
@@ -18,13 +18,15 @@ package com.example.android.miwok;
 import android.content.Context;
 import android.media.AudioManager;
 import android.media.MediaPlayer;
-import android.support.v7.app.AppCompatActivity;
+
 import android.os.Bundle;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ListView;
 
 import java.util.ArrayList;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 public class PhrasesActivity extends AppCompatActivity {
 

--- a/app/src/main/java/com/example/android/miwok/PhrasesActivity.java
+++ b/app/src/main/java/com/example/android/miwok/PhrasesActivity.java
@@ -27,6 +27,9 @@ import android.widget.ListView;
 import java.util.ArrayList;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.media.AudioAttributesCompat;
+import androidx.media.AudioFocusRequestCompat;
+import androidx.media.AudioManagerCompat;
 
 public class PhrasesActivity extends AppCompatActivity {
 
@@ -36,57 +39,70 @@ public class PhrasesActivity extends AppCompatActivity {
     /** Handles audio focus when playing a sound file */
     private AudioManager mAudioManager;
 
-    /**
-     * This listener gets triggered when the {@link MediaPlayer} has completed
-     * playing the audio file.
-     */
-    private MediaPlayer.OnCompletionListener mCompletionListener = new MediaPlayer.OnCompletionListener() {
-        @Override
-        public void onCompletion(MediaPlayer mediaPlayer) {
-            // Now that the sound file has finished playing, release the media player resources.
-            releaseMediaPlayer();
-        }
-    };
+    private AudioFocusRequestCompat mAudioFocusRequest;
+    private MediaPlayer.OnCompletionListener mOnCompletionListener;
 
-    /**
-     * This listener gets triggered whenever the audio focus changes
-     * (i.e., we gain or lose audio focus because of another app or device).
-     */
-    private AudioManager.OnAudioFocusChangeListener mOnAudioFocusChangeListener = new AudioManager.OnAudioFocusChangeListener() {
-        @Override
-        public void onAudioFocusChange(int focusChange) {
-            if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT ||
-                    focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK) {
-                // The AUDIOFOCUS_LOSS_TRANSIENT case means that we've lost audio focus for a
-                // short amount of time. The AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK case means that
-                // our app is allowed to continue playing sound but at a lower volume. We'll treat
-                // both cases the same way because our app is playing short sound files.
-
-                // Pause playback and reset player to the start of the file. That way, we can
-                // play the word from the beginning when we resume playback.
-                mMediaPlayer.pause();
-                mMediaPlayer.seekTo(0);
-            } else if (focusChange == AudioManager.AUDIOFOCUS_GAIN) {
-                // The AUDIOFOCUS_GAIN case means we have regained focus and can resume playback.
-                mMediaPlayer.start();
-            } else if (focusChange == AudioManager.AUDIOFOCUS_LOSS) {
-                // The AUDIOFOCUS_LOSS case means we've lost audio focus and
-                // Stop playback and clean up resources
-                releaseMediaPlayer();
-            }
-        }
-    };
+    private ArrayList<Word> words;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.word_list);
 
+
+        mOnCompletionListener = new MediaPlayer.OnCompletionListener() {
+            @Override
+            public void onCompletion(MediaPlayer mp) {
+                releaseMediaPlayer();
+            }
+        };
+
+        /*
+         * This listener gets triggered whenever the audio focus changes
+         * (i.e., we gain or lose audio focus because of another app or device).
+         */
+         AudioManager.OnAudioFocusChangeListener audioFocusChangeListener  = new AudioManager.OnAudioFocusChangeListener() {
+            @Override
+            public void onAudioFocusChange(int focusChange) {
+                if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT ||
+                        focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK) {
+                    // The AUDIOFOCUS_LOSS_TRANSIENT case means that we've lost audio focus for a
+                    // short amount of time. The AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK case means that
+                    // our app is allowed to continue playing sound but at a lower volume. We'll treat
+                    // both cases the same way because our app is playing short sound files.
+
+                    // Pause playback and reset player to the start of the file. That way, we can
+                    // play the word from the beginning when we resume playback.
+                    mMediaPlayer.pause();
+                    mMediaPlayer.seekTo(0);
+                } else if (focusChange == AudioManager.AUDIOFOCUS_GAIN) {
+                    // The AUDIOFOCUS_GAIN case means we have regained focus and can resume playback.
+                    mMediaPlayer.start();
+                } else if (focusChange == AudioManager.AUDIOFOCUS_LOSS) {
+                    // The AUDIOFOCUS_LOSS case means we've lost audio focus and
+                    // Stop playback and clean up resources
+                    releaseMediaPlayer();
+                }
+            }
+        };
+
         // Create and setup the {@link AudioManager} to request audio focus
         mAudioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
 
+        AudioAttributesCompat audioAttributes = new AudioAttributesCompat.Builder()
+                .setContentType(AudioAttributesCompat.CONTENT_TYPE_SPEECH)
+                .setUsage(AudioAttributesCompat.USAGE_MEDIA)
+                .build();
+
+        mAudioFocusRequest = new AudioFocusRequestCompat
+                .Builder(AudioManagerCompat.AUDIOFOCUS_GAIN_TRANSIENT)
+                .setAudioAttributes(audioAttributes)
+                .setOnAudioFocusChangeListener(audioFocusChangeListener)
+                .build();
+
+
         // Create a list of words
-        final ArrayList<Word> words = new ArrayList<Word>();
+         words = new ArrayList<>();
         words.add(new Word(R.string.phrase_where_are_you_going,
                 R.string.miwok_phrase_where_are_you_going, R.raw.phrase_where_are_you_going));
         words.add(new Word(R.string.phrase_what_is_your_name,
@@ -115,7 +131,7 @@ public class PhrasesActivity extends AppCompatActivity {
         // Find the {@link ListView} object in the view hierarchy of the {@link Activity}.
         // There should be a {@link ListView} with the view ID called list, which is declared in the
         // word_list.xml layout file.
-        ListView listView = (ListView) findViewById(R.id.list);
+        ListView listView = findViewById(R.id.list);
 
         // Make the {@link ListView} use the {@link WordAdapter} we created above, so that the
         // {@link ListView} will display list items for each {@link Word} in the list.
@@ -135,8 +151,7 @@ public class PhrasesActivity extends AppCompatActivity {
                 // Request audio focus so in order to play the audio file. The app needs to play a
                 // short audio file, so we will request audio focus with a short amount of time
                 // with AUDIOFOCUS_GAIN_TRANSIENT.
-                int result = mAudioManager.requestAudioFocus(mOnAudioFocusChangeListener,
-                        AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN_TRANSIENT);
+                int result =AudioManagerCompat.requestAudioFocus(mAudioManager, mAudioFocusRequest);
 
                 if (result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
                     // We have audio focus now.
@@ -150,7 +165,7 @@ public class PhrasesActivity extends AppCompatActivity {
 
                     // Setup a listener on the media player, so that we can stop and release the
                     // media player once the sound has finished playing.
-                    mMediaPlayer.setOnCompletionListener(mCompletionListener);
+                    mMediaPlayer.setOnCompletionListener(mOnCompletionListener);
                 }
             }
         });
@@ -181,7 +196,7 @@ public class PhrasesActivity extends AppCompatActivity {
 
             // Regardless of whether or not we were granted audio focus, abandon it. This also
             // unregisters the AudioFocusChangeListener so we don't get anymore callbacks.
-            mAudioManager.abandonAudioFocus(mOnAudioFocusChangeListener);
+            AudioManagerCompat.abandonAudioFocusRequest(mAudioManager, mAudioFocusRequest);
         }
     }
 }

--- a/app/src/main/java/com/example/android/miwok/WordAdapter.java
+++ b/app/src/main/java/com/example/android/miwok/WordAdapter.java
@@ -16,7 +16,7 @@
 package com.example.android.miwok;
 
 import android.content.Context;
-import android.support.v4.content.ContextCompat;
+
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -25,6 +25,8 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import java.util.ArrayList;
+
+import androidx.core.content.ContextCompat;
 
 /**
  * {@link WordAdapter} is an {@link ArrayAdapter} that can provide the layout for each list item

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,14 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:3.6.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -15,6 +20,10 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,6 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+android.useAndroidX=true
+android.enableJetifier=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Sat May 02 00:20:00 BST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat May 02 00:20:00 BST 2020
+#Sat Oct 03 00:23:49 BST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION



Hi,
This is the lesson:
 Multi-Screen Apps -> Lesson 8: Activity Lifecycle and Audio Playback -> 26. quiz: Manage Audio Focus in the [app.](https://classroom.udacity.com/nanodegrees/nd803/parts/f727e50b-703c-4170-bd6a-dca19cc04283/modules/7e414fd4-48ba-4939-852d-43e292a1d32a/lessons/8e669b70-81c0-4761-b58a-020463ede18f/concepts/80820923130923)


 [Udacity solution for this quiz is here.](https://github.com/udacity/ud839_Miwok/commit/2b548eae0e57d7ad0cbb9c77656fd24215ec6cb4)

My solution is based on that and I updated the Gradle and deprecated methods(elements) in the java files.

I did this update because I wanted to use a working version after migrating AndroidX into this project.
Fixes #212 
