### PR TITLE
updated gradle to 4.1.0 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
+
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -14,6 +16,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
The error is now solved .
--The gradle related error comes when there is update needed
--just change the "build.gradle" and "gradle-wrapper.properties" 
#replace :
1) classpath 'com.android.tools.build:gradle:4.1.0' in build.gradle
2) google() in build.gradle under repositories near jcentre()
3)distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip in gradle-wrapper.properties
and done
